### PR TITLE
HWK: remove host perms and JSON-from-url field

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,23 @@
 module.exports = {
-    "extends": "standard",
-    "installedESLint": true,
-    "plugins": [
-        "standard"
-    ],
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "ecmaFeatures": {
-            "jsx": true
-        }
+    extends: 'standard',
+    plugins: ['standard'],
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+        },
     },
-    "env": {
-        "browser": true,
-        "jquery": true,
-        "es6": true
+    env: {
+        browser: true,
+        jquery: true,
+        es6: true,
     },
-    "rules": {
-        "indent": ["error", 4],
-        "semi": ["error", "always", { "omitLastInOneLineBlock": true}],
-        "one-var": "off"
+    rules: {
+        indent: ['error', 4],
+        semi: ['error', 'always', { omitLastInOneLineBlock: true }],
+        'one-var': 'off',
     },
-    "globals": {
-        "utils": false
-    }
+    globals: {
+        utils: false,
+    },
 };

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The JSON format is:
 * Templates are synced across devices.
   * Configure once, use on all chrome devices that support extensions!
 * Reload default templates with one click.
-* Load templates from url (json file). Host a single json file and have everyone use the same templates.
 * Load templates from local file (json). Easily share templates with other users.
 * Add/Remove/Edit individual templates.
 * Add/Remove custom domains.
@@ -62,7 +61,6 @@ The JSON format is:
 * Limit interface options (To keep templates consistent across users)
     * Current limit options are:
         * "all"         -> disable all interface actions except reload default
-        * "url"         -> disable loading of json from url
         * "file"        -> disable loading of json from local file
         * "clear"       -> disable clearing of all templates
         * "delete"      -> disable deleting single template

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -69,22 +69,6 @@ https://github.com/rdbrck/jira-description-extension/blob/master/LICENSE
                 <div class="divider"></div>
                 <div class="section">
                     <div class="row">
-                        <div class="col s5 valign-wrapper">
-                            <h6 class="valign-wrapper"> Load JSON from URL:</h6>
-                        </div>
-                        <div class="col s5">
-                            <input id="jsonURLInput" type="text" name="url" placeholder="URL to JSON file">
-                        </div>
-                        <div class="col s2 right-align">
-                            <a id="download" class="btn-floating btn-jti tooltipped" data-position="left" data-delay="50" data-tooltip="Download Templates">
-                                <i class="material-icons">cloud_download</i>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <div class="divider"></div>
-                <div class="section">
-                    <div class="row">
                         <div class="col s3 valign-wrapper">
                             <h6 class="valign-wrapper"> Select file:</h6>
                         </div>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,9 +30,7 @@
     },
     "content_scripts": [
         {
-            "matches": [
-                "<all_urls>"
-            ],
+            "matches": ["<all_urls>"],
             "js": [
                 "lib/jquery/jquery-2.2.3.js",
                 "js/utils.js",
@@ -44,10 +42,5 @@
     "sandbox": {
         "pages": ["html/sandbox.html"]
     },
-    "permissions": [
-        "storage",
-        "tabs",
-        "*://*/*.json",
-        "https://*.pingstatsnet.com/"
-    ]
+    "permissions": ["storage", "tabs"]
 }


### PR DESCRIPTION
The Chrome Store didn't like that we had those. Sadly, this means you can't fetch JSON from URLs anymore.

There is another branch to move to manifest v3, but that involves moving everything into service workers, which means you can't use jQuery DOM selectors, etc. and it's a bit hairy. This addresses the immediate problem while staying on manifest v2.